### PR TITLE
Resize helix logo to match other logos

### DIFF
--- a/public/static/shared-logos/products/helix.svg
+++ b/public/static/shared-logos/products/helix.svg
@@ -11,12 +11,12 @@
    id="Warstwa_1"
    x="0px"
    y="0px"
-   viewBox="0 0 150 160.69652"
+   viewBox="0 0 50.000001 53.565505"
    xml:space="preserve"
-   sodipodi:docname="logo.svg"
-   width="39.6875mm"
-   height="42.51762mm"
-   inkscape:version="1.0.1 (c497b03c, 2020-09-10)"><sodipodi:namedview
+   sodipodi:docname="helix.svg"
+   width="13.229167mm"
+   height="14.17254mm"
+   inkscape:version="1.0.2 (e86c8708, 2021-01-15)"><sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
      borderopacity="1"
@@ -30,10 +30,10 @@
      id="namedview848"
      showgrid="false"
      inkscape:zoom="1.6552944"
-     inkscape:cx="203.46808"
+     inkscape:cx="98.048766"
      inkscape:cy="156.43154"
-     inkscape:window-x="0"
-     inkscape:window-y="144"
+     inkscape:window-x="1"
+     inkscape:window-y="51"
      inkscape:window-maximized="0"
      inkscape:current-layer="GraphQL-Tools_x2F_-Scalars"
      units="mm"
@@ -41,10 +41,11 @@
      fit-margin-top="0"
      fit-margin-left="0"
      fit-margin-right="0"
-     fit-margin-bottom="0" /><metadata
+     fit-margin-bottom="0"
+     inkscape:document-rotation="0" /><metadata
      id="metadata916"><rdf:RDF><cc:Work
          rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata><defs
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title /></cc:Work></rdf:RDF></metadata><defs
      id="defs914" /><style
      type="text/css"
      id="style903">
@@ -53,9 +54,9 @@
 	.st2{fill:#6D7A99;}
 </style><g
      id="GraphQL-Tools_x2F_-Scalars"
-     transform="translate(-0.7314361,-0.07938882)"><g
+     transform="translate(-0.7314361,-0.07938894)"><g
    id="Libraries-Logos-_x2F_-Scalars"
-   transform="matrix(2.4875622,0,0,2.4875622,8.1941227,42.11919)"><path
+   transform="matrix(0.8291874,0,0,0.8291874,3.2189983,14.092656)"><path
      id="Fill-2"
      class="st0"
      d="m 32.4,42.9 c 0,0.3 0,0.5 -0.1,0.7 0,0 0,0.1 0,0.1 -0.4,2.3 -2.4,4 -4.8,4 -2.1,0 -4,-1.4 -4.6,-3.3 L 2.7,32.8 c -2,-1.2 -3.2,-3.3 -3.2,-5.6 V 7.4 C 0.2,7.7 1,7.8 1.8,7.8 2.5,7.8 3.3,7.7 4,7.5 v 19.7 c 0,0.7 0.4,1.3 1,1.7 l 18.9,10.9 c 0.9,-1 2.2,-1.7 3.7,-1.7 1.6,0 3,0.8 3.9,2 0,0 0,0 0,0.1 0.1,0.1 0.1,0.2 0.2,0.3 0,0 0,0.1 0.1,0.1 0,0.1 0.1,0.2 0.1,0.3 0,0 0,0.1 0.1,0.1 0,0.1 0.1,0.2 0.1,0.3 0,0.1 0,0.1 0.1,0.2 0,0.1 0.1,0.2 0.1,0.2 0,0.1 0,0.2 0.1,0.2 0,0.1 0,0.1 0,0.2 0,0.1 0,0.2 0,0.3 0,0.1 0,0.1 0,0.2 0,0 0,0.2 0,0.3 z M 57.3,0.3 c 0,1.5 -0.6,2.8 -1.7,3.7 v 23.1 c 0,2.3 -1.2,4.5 -3.2,5.6 L 35,42.8 c 0,-1.6 -0.6,-3.2 -1.5,-4.4 l 16.6,-9.6 c 0.6,-0.3 1,-1 1,-1.7 V 5 c -2,-0.6 -3.5,-2.5 -3.5,-4.7 0,-1.1 0.4,-2.1 1,-2.9 0,0 0,0 0,0 0.1,-0.1 0.2,-0.3 0.4,-0.4 v 0 c 0.3,-0.3 0.6,-0.5 0.9,-0.7 0,0 0.1,0 0.1,-0.1 0,-0.1 0.2,-0.2 0.3,-0.3 0,0 0.1,0 0.1,-0.1 0.2,-0.1 0.3,-0.1 0.5,-0.2 0,0 0,0 0,0 0.5,-0.1 1,-0.2 1.5,-0.2 2.7,0.1 4.9,2.2 4.9,4.9 z M -0.5,4.6 C -2,3.7 -3,2.2 -3,0.3 c 0,-2.7 2.2,-4.9 4.9,-4.9 0.7,0 1.4,0.2 2,0.4 L 24.3,-16 c 1,-0.6 2.1,-0.9 3.2,-0.9 1.1,0 2.2,0.3 3.2,0.9 L 48.3,-5.9 C 47,-5 46,-3.7 45.4,-2.3 l -16.9,-9.8 c -0.3,-0.2 -0.6,-0.3 -1,-0.3 -0.3,0 -0.7,0.1 -1,0.3 L 6.6,-0.5 c 0,0.3 0.1,0.6 0.1,0.8 0,2.1 -1.3,3.9 -3.2,4.6 0,0 0,0 0,0 C 3.3,5 3.2,5 3,5.1 c 0,0 -0.1,0 -0.1,0 -0.1,0 -0.3,0.1 -0.4,0.1 0,0 -0.1,0 -0.1,0 -0.2,0 -0.4,0 -0.5,0 -0.2,0 -0.4,0 -0.6,0 -0.1,0 -0.1,0 -0.2,0 C 1,5.1 0.8,5.1 0.7,5.1 c 0,0 -0.1,0 -0.1,0 C 0.2,4.9 -0.2,4.8 -0.5,4.6 Z"


### PR DESCRIPTION
All the other logos(even if svg format) are a width of 50px by default. I resized it match those such that my other PR that fixes it in the platform dropdown in the header won't be disproportionate.