### PR TITLE
Fix typo for GraphQL Yoga

### DIFF
--- a/website/pages/blog/slack-bot-with-cloudflare.mdx
+++ b/website/pages/blog/slack-bot-with-cloudflare.mdx
@@ -147,4 +147,4 @@ Our focus is on easy setup, performance, and great developer experience.
 
 Thanks to its platform-agnostic design, Yoga makes your GraphQL Server run everywhere, even on Cloudflare Workers, with no additional packages required!
 
-You can find more information and tutorials on how to integrate **Cloudflare Workers** with **GrpahQL Yoga** - [link](https://www.graphql-yoga.com/docs/integrations/integration-with-cloudflare-workers).
+You can find more information and tutorials on how to integrate **Cloudflare Workers** with **GraphQL Yoga** - [link](https://www.graphql-yoga.com/docs/integrations/integration-with-cloudflare-workers).


### PR DESCRIPTION
Fixed a small typo in the "Building Slack bot with Cloudflare Workers" blog post.