### PR TITLE
fix: redirect deprecated Hive registry token link

### DIFF
--- a/packages/website-router/src/config.ts
+++ b/packages/website-router/src/config.ts
@@ -101,6 +101,11 @@ export const jsonConfig = {
       crisp: { segments: ['hive-website'] },
       sitemap: false,
     },
+    '/graphql/hive/docs/schema-registry/management': {
+      redirect:
+        'https://the-guild.dev/graphql/hive/docs/schema-registry/management/targets#registry-access-tokens',
+      status: 302,
+    },
     '/graphql/hive': {
       rewrite: 'hive-platform-docs.theguild.workers.dev',
       preserveSearch: true,


### PR DESCRIPTION
Fixes #1886

## Summary
- Add a redirect for the deprecated Hive schema registry management URL to the target management section that contains the Registry Access Tokens anchor.

## Testing
- pnpm --filter guild-website-router typecheck
- pnpm prettier --check packages/website-router/src/config.ts
- pnpm --filter guild-website-router test